### PR TITLE
Add company info for Binary Tree Preorder Traversal

### DIFF
--- a/data/company_info.json
+++ b/data/company_info.json
@@ -11263,6 +11263,7 @@
   ],
   "https://leetcode.com/problems/binary-tree-preorder-traversal/": [
     "Binary Tree Preorder Traversal",
+    "TCS",
     "Adobe",
     "Google"
   ],


### PR DESCRIPTION
This PR adds company-related information for the "Tree Preorder Traversal" problem.
Companies included: TCS.
